### PR TITLE
Add batch enqueue & next support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2022-03-05
+### Added
+- `/enqueue/batch` endpoint for efficient batch/bulk creation of Jobs.
+- Refactored `/next` endpoint to accept an optional number of Jobs to return for fetching a batch of Jobs.
+
+## [0.2.0] - 2022-02-27
+### Added
+- Future Job support using new `run_at` Job field.
+- Reschedule endpoint allowing the Job Runner to manage a unique/singleton Job rescheduling itself.
+
+[Unreleased]: https://github.com/rust-playground/relay-rs/compare/relay-v0.3.0...HEAD
+[0.3.0]: https://github.com/rust-playground/relay-rs/compare/55f4ffca5f12ebce195d6b53cf2d2f92c9036614...v0.3.0
+[0.2.0]: https://github.com/rust-playground/relay-rs/commit/55f4ffca5f12ebce195d6b53cf2d2f92c9036614

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3fdd63b9cfeaf92eeeece719dabbddddb420a57d3fd171ce1490ecfb7086b1"
+checksum = "bc14de609ea2ae2467f5a626d403082ce3c5ca248ba26c9ee6f617a5fd096517"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.2"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
 dependencies = [
  "atty",
  "bitflags",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -1568,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -2186,18 +2186,18 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "relay"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix-web",
  "anydate",
@@ -1759,7 +1759,7 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scheduler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-web",
  "ahash",

--- a/relay/API.md
+++ b/relay/API.md
@@ -46,28 +46,80 @@ NOTE: The body of the response will have more detail about the specific error.
 
 
 
+### `POST /enqueue/batch`
+
+Enqueues multiple `Jobs` to be processed in one call.
+
+**NOTE:**
+That this function will not return an error for conflicts in Job ID, but rather 
+silently drop the record using an `ON CONFLICT DO NOTHING`. If you need to have a
+Conflict error returned it is recommended to use the `enqueue` function for a single
+Job instead.
+
+#### Arguments
+In this case the only arguments are part of the Body payload.
+
+| argument    | required | description                                                                                                                                                                            |
+|-------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`          | true     | The unique Job Id which is also CAN be used to ensure the Job is a singleton within a Queue.                                                                                           |
+| `queue`       | true     | Is used to differentiate different job types that can be picked up by job runners.                                                                                                     |
+| `timeout`     | true     | Denotes the duration, in seconds, after a Job has started processing or since the last heartbeat request occurred before considering the Job failed and being put back into the queue. |
+| `max_retries` | false    | Determines how many times the Job can be retried, due to timeouts, before being considered.                                                                                            |
+| `payload`     | false    | The raw JSON payload that the job runner will receive.                                                                                                                                 |
+| `run_at`      | false    | Schedule/set a Job to be run only at a specific time in the future.                                                                                                                    |
+
+#### Request Body
+```json
+[
+    {
+      "id": "1",
+      "queue": "my-queue",
+      "timeout": 30,
+      "max_retries": 0,
+      "payload": "RAW JSON"
+    }
+]
+```
+
+### Response Codes
+
+NOTE: The body of the response will have more detail about the specific error.
+
+| code  | description                                                                 |
+|-------|-----------------------------------------------------------------------------|
+| 202   | Job enqueued and accepted for processing.                                   |
+| 400   | For a bad/ill-formed request.                                               |
+| 429   | A retryable error occurred. Most likely the backing storage having issues.  |
+| 422   | A permanent error has occurred.                                             |
+| 500   | An unknown error has occurred server side.                                  |
+
+
+
 ### `GET /v1/next`
 
-Retrieves the next Job to be processed based on the provided queue.
+Retrieves the next `Job(s)` to be processed based on the provided `queue`.
 
 #### Arguments
 In this case the only arguments are query params.
 
-| argument | required | description                                         |
-|----------|----------|-----------------------------------------------------|
-| queue    | true     | Used to pull the next job from the requested queue. |
+| argument | required | description                                                                    |
+|----------|----------|--------------------------------------------------------------------------------|
+| `queue`    | true     | Used to pull the next job from the requested queue.                            |
+| `num_jobs` | false    | Specifies how many Jobs to pull to process next in one request. Defaults to 1. |
 
 #### Response Body
 Some fields may not be present such as `state` when none exists.
 ```json
-{
-  "id": "1",
-  "queue": "my-queue",
-  "timeout": 30,
-  "max_retries": 0,
-  "payload": "RAW JSON",
-  "state": "RAW JSON"
-}
+[
+    {
+      "id": "1",
+      "queue": "my-queue",
+      "timeout": 30,
+      "max_retries": 0,
+      "payload": "RAW JSON",
+      "state": "RAW JSON"
+    }
+]
 ```
 
 #### Response Codes

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.55"
-clap = { version = "3.1.2", features = ["derive", "env"] }
+clap = { version = "3.1.5", features = ["derive", "env"] }
 tokio = { version = "1.17.0", features = ["rt-multi-thread", "net", "time","macros"] }
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 metrics-exporter-prometheus = { version = "0.8.0", optional = true }

--- a/relay/src/http.rs
+++ b/relay/src/http.rs
@@ -23,11 +23,11 @@
 //! #### Request Body
 //! ```json
 //! {
-//! "id": "1",
-//! "queue": "my-queue",
-//! "timeout": 30,
-//! "max_retries": 0,
-//! "payload": "RAW JSON"
+//!     "id": "1",
+//!     "queue": "my-queue",
+//!     "timeout": 30,
+//!     "max_retries": 0,
+//!     "payload": "RAW JSON"
 //! }
 //! ```
 //!
@@ -46,28 +46,80 @@
 //!
 //!
 //!
+//! ### `POST /enqueue/batch`
+//!
+//! Enqueues multiple `Jobs` to be processed in one call.
+//!
+//! **NOTE:**
+//! That this function will not return an error for conflicts in Job ID, but rather
+//! silently drop the record using an `ON CONFLICT DO NOTHING`. If you need to have a
+//! Conflict error returned it is recommended to use the `enqueue` function for a single
+//! Job instead.
+//!
+//! #### Arguments
+//! In this case the only arguments are part of the Body payload.
+//!
+//! | argument    | required | description                                                                                                                                                                            |
+//! |-------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+//! | `id`          | true     | The unique Job Id which is also CAN be used to ensure the Job is a singleton within a Queue.                                                                                           |
+//! | `queue`       | true     | Is used to differentiate different job types that can be picked up by job runners.                                                                                                     |
+//! | `timeout`     | true     | Denotes the duration, in seconds, after a Job has started processing or since the last heartbeat request occurred before considering the Job failed and being put back into the queue. |
+//! | `max_retries` | false    | Determines how many times the Job can be retried, due to timeouts, before being considered.                                                                                            |
+//! | `payload`     | false    | The raw JSON payload that the job runner will receive.                                                                                                                                 |
+//! | `run_at`      | false    | Schedule/set a Job to be run only at a specific time in the future.                                                                                                                    |
+//!
+//! #### Request Body
+//! ```json
+//! [
+//!     {
+//!         "id": "1",
+//!         "queue": "my-queue",
+//!         "timeout": 30,
+//!         "max_retries": 0,
+//!         "payload": "RAW JSON"
+//!     }
+//! ]
+//! ```
+//!
+//! ### Response Codes
+//!
+//! NOTE: The body of the response will have more detail about the specific error.
+//!
+//! | code  | description                                                                 |
+//! |-------|-----------------------------------------------------------------------------|
+//! | 202   | Job enqueued and accepted for processing.                                   |
+//! | 400   | For a bad/ill-formed request.                                               |
+//! | 429   | A retryable error occurred. Most likely the backing storage having issues.  |
+//! | 422   | A permanent error has occurred.                                             |
+//! | 500   | An unknown error has occurred server side.                                  |
+//!
+//!
+//!
 //! ### `GET /v1/next`
 //!
-//! Retrieves the next Job to be processed based on the provided queue.
+//! Retrieves the next `Job(s)` to be processed based on the provided `queue`.
 //!
 //! #### Arguments
 //! In this case the only arguments are query params.
 //!
-//! | argument | required | description                                         |
-//! |----------|----------|-----------------------------------------------------|
-//! | `queue`    | true     | Used to pull the next job from the requested queue. |
+//! | argument | required | description                                                                    |
+//! |----------|----------|--------------------------------------------------------------------------------|
+//! | `queue`    | true     | Used to pull the next job from the requested queue.                            |
+//! | `num_jobs` | false    | Specifies how many Jobs to pull to process next in one request. Defaults to 1. |
 //!
 //! #### Response Body
 //! Some fields may not be present such as `state` when none exists.
 //! ```json
-//! {
-//! "id": "1",
-//! "queue": "my-queue",
-//! "timeout": 30,
-//! "max_retries": 0,
-//! "payload": "RAW JSON",
-//! "state": "RAW JSON"
-//! }
+//! [
+//!     {
+//!         "id": "1",
+//!         "queue": "my-queue",
+//!         "timeout": 30,
+//!         "max_retries": 0,
+//!         "payload": "RAW JSON",
+//!         "state": "RAW JSON"
+//!     }
+//! ]
 //! ```
 //!
 //! #### Response Codes
@@ -133,11 +185,11 @@
 //! #### Request Body
 //! ```json
 //! {
-//! "id": "1",
-//! "queue": "my-queue",
-//! "timeout": 30,
-//! "max_retries": 0,
-//! "payload": "RAW JSON"
+//!     "id": "1",
+//!     "queue": "my-queue",
+//!     "timeout": 30,
+//!     "max_retries": 0,
+//!     "payload": "RAW JSON"
 //! }
 //! ```
 //!
@@ -149,7 +201,7 @@
 //! |-------|-----------------------------------------------------------------------------|
 //! | 202   | Job enqueued and accepted for processing.                                   |
 //! | 400   | For a bad/ill-formed request.                                               |
-//! | 409   | An conflicting Job already exists with the provided id and queue.           |
+//! | 404   | Job was not found for updating.                                             |
 //! | 429   | A retryable error occurred. Most likely the backing storage having issues.  |
 //! | 422   | A permanent error has occurred.                                             |
 //! | 500   | An unknown error has occurred server side.                                  |
@@ -197,10 +249,10 @@ use tracing::{error, info};
 pub struct Server;
 
 async fn enqueue(data: web::Data<Data>, job: web::Json<Job>) -> HttpResponse {
-    increment_counter!("http_request", "endpoint" => "enqueued", "queue" => job.0.queue.clone());
+    increment_counter!("http_request", "endpoint" => "enqueue", "queue" => job.0.queue.clone());
 
     if let Err(e) = data.pg_store.enqueue(&job.0).await {
-        increment_counter!("errors", "endpoint" => "enqueued", "type" => e.error_type(), "queue" => e.queue());
+        increment_counter!("errors", "endpoint" => "enqueue", "type" => e.error_type(), "queue" => e.queue());
         match e {
             Error::JobExists { .. } => {
                 HttpResponse::build(StatusCode::CONFLICT).body(e.to_string())
@@ -221,15 +273,41 @@ async fn enqueue(data: web::Data<Data>, job: web::Json<Job>) -> HttpResponse {
     }
 }
 
+async fn enqueue_batch(data: web::Data<Data>, jobs: web::Json<Vec<Job>>) -> HttpResponse {
+    increment_counter!("http_request", "endpoint" => "enqueue_batch");
+
+    if let Err(e) = data.pg_store.enqueue_batch(&jobs.0).await {
+        increment_counter!("errors", "endpoint" => "enqueue_batch", "type" => e.error_type());
+        match e {
+            Error::Postgres { .. } => {
+                if e.is_retryable() {
+                    HttpResponse::build(StatusCode::TOO_MANY_REQUESTS).body(e.to_string())
+                } else {
+                    HttpResponse::build(StatusCode::UNPROCESSABLE_ENTITY).body(e.to_string())
+                }
+            }
+            _ => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).body(e.to_string()),
+        }
+    } else {
+        HttpResponse::build(StatusCode::ACCEPTED).finish()
+    }
+}
+
 #[derive(Deserialize)]
 struct NextInfo {
     queue: String,
+    #[serde(default = "default_num_jobs")]
+    num_jobs: u32,
+}
+
+const fn default_num_jobs() -> u32 {
+    1
 }
 
 async fn next(data: web::Data<Data>, info: web::Query<NextInfo>) -> HttpResponse {
     increment_counter!("http_request", "endpoint" => "next", "queue" => info.queue.clone());
 
-    match data.pg_store.next(&info.queue).await {
+    match data.pg_store.next(&info.queue, info.num_jobs).await {
         Err(e) => {
             increment_counter!("errors", "endpoint" => "next", "type" => e.error_type(), "queue" => e.queue());
             if let Error::Postgres { .. } = e {
@@ -396,6 +474,7 @@ impl Server {
                 .app_data(store.clone())
                 .wrap(Logger::new("%a %r %s %Dms"))
                 .route("/enqueue", web::post().to(enqueue))
+                .route("/enqueue/batch", web::post().to(enqueue_batch))
                 .route("/heartbeat", web::patch().to(heartbeat))
                 .route("/reschedule", web::post().to(reschedule))
                 .route("/complete", web::delete().to(complete))

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.55"
-clap = { version = "3.1.2", features = ["derive", "env"] }
+clap = { version = "3.1.5", features = ["derive", "env"] }
 tokio = { version = "1.17.0", features = ["rt-multi-thread", "net", "time","macros"] }
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 metrics-exporter-prometheus = { version = "0.8.0", optional = true }

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scheduler"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
### Added
- Batch enqueue endpoint `/enqueue/batch`
- Refactored `/next` endpoint to accept number of Jobs to return.