### PR TITLE
Fix SELECT LIMIT optimized badly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.5.2] - 2022-04-22
-### Foxed
+### Fixed
 - Next update query when under very specific circumstances the Postgres query planner can do the wrong thing. See here for a detailed example https://github.com/feikesteenbergen/demos/blob/19522f66ffb6eb358fe2d532d9bdeae38d4e2a0b/bugs/update_from_correlated.adoc
+
+### Added
+- Requirements section to README.
 
 ## [0.5.1] - 2022-04-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2022-04-22
+### Foxed
+- Next update query when under very specific circumstances the Postgres query planner can do the wrong thing. See here for a detailed example https://github.com/feikesteenbergen/demos/blob/19522f66ffb6eb358fe2d532d9bdeae38d4e2a0b/bugs/update_from_correlated.adoc
+
+## [0.5.1] - 2022-04-22
+### Added
+- Automatic docker image build and push.
+
 ## [0.5.0] - 2022-04-22
 ### Fixed
 - Updated job schema to add uuid. This fixes a locking issue when grabbing new items using IN rather than a SELECT FROM.
@@ -24,7 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Future Job support using new `run_at` Job field.
 - Reschedule endpoint allowing the Job Runner to manage a unique/singleton Job rescheduling itself.
 
-[Unreleased]: https://github.com/rust-playground/relay-rs/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/rust-playground/relay-rs/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/rust-playground/relay-rs/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/rust-playground/relay-rs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/rust-playground/relay-rs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/rust-playground/relay-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/rust-playground/relay-rs/compare/55f4ffca5f12ebce195d6b53cf2d2f92c9036614...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base-x"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
 
 [[package]]
 name = "base64"
@@ -1585,7 +1585,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "relay"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "actix-web",
  "anydate",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relay"
-version = "0.5.0"
+version = "0.5.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/relay/README.md
+++ b/relay/README.md
@@ -8,6 +8,9 @@ Optional features:
 
 [`metrics-prometheus`]: https://crates.io/crates/metrics-exporter-prometheus
 
+#### Requirements
+- Postgres 9.5+
+
 #### API
 For details about the API see [here](./API.md). 
 

--- a/relay/migrations/20220423082425_revert.sql
+++ b/relay/migrations/20220423082425_revert.sql
@@ -1,0 +1,1 @@
+ALTER TABLE jobs DROP COLUMN IF EXISTS "iid" ;

--- a/relay/src/postgres.rs
+++ b/relay/src/postgres.rs
@@ -223,15 +223,17 @@ impl PgStore {
     ///
     /// Will return `Err` if there is any communication issues with the backend Postgres DB.
     pub async fn next(&self, queue: &Queue, num_jobs: u32) -> Result<Option<Vec<Job>>> {
+        // MUST USE CTE WITH `FOR UPDATE SKIP LOCKED LIMIT` otherwise the Postgres Query Planner
+        // CAN optimize the query which will cause MORE updates than the LIMIT specifies within
+        // a nested loop.
+        // See here for details:
+        // https://github.com/feikesteenbergen/demos/blob/master/bugs/update_from_correlated.adoc
         let jobs = sqlx::query(
             r#"
-               UPDATE jobs j
-               SET in_flight=true,
-                   updated_at=NOW(),
-                   expires_at=NOW()+timeout
-               WHERE iid IN (
-                    SELECT
-                        iid
+               WITH subquery AS (
+                   SELECT
+                        id,
+                        queue
                    FROM jobs
                    WHERE
                         queue=$1 AND
@@ -241,6 +243,14 @@ impl PgStore {
                    FOR UPDATE SKIP LOCKED
                    LIMIT $2
                )
+               UPDATE jobs j
+               SET in_flight=true,
+                   updated_at=NOW(),
+                   expires_at=NOW()+timeout
+               FROM subquery
+               WHERE
+                   j.queue=subquery.queue AND
+                   j.id=subquery.id
                RETURNING j.id,
                          j.queue,
                          j.timeout,

--- a/relay/src/postgres.rs
+++ b/relay/src/postgres.rs
@@ -227,7 +227,7 @@ impl PgStore {
         // CAN optimize the query which will cause MORE updates than the LIMIT specifies within
         // a nested loop.
         // See here for details:
-        // https://github.com/feikesteenbergen/demos/blob/master/bugs/update_from_correlated.adoc
+        // https://github.com/feikesteenbergen/demos/blob/19522f66ffb6eb358fe2d532d9bdeae38d4e2a0b/bugs/update_from_correlated.adoc
         let jobs = sqlx::query(
             r#"
                WITH subquery AS (


### PR DESCRIPTION
MUST USE CTE WITH `FOR UPDATE SKIP LOCKED LIMIT` otherwise the Postgres Query Planner
CAN optimize the query which will cause MORE updates than the `LIMIT` specifies within a nested loop.

See here for details: https://github.com/feikesteenbergen/demos/blob/master/bugs/update_from_correlated.adoc