### PR TITLE
Relax reschedule state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2022-05-13
+### Changed
+- Reschedule to accept setting/unsetting of state.
+
 ## [0.5.3] - 2022-05-07
 ### Fixed
 - Fixed recursive function call in is_retryable().
@@ -52,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Future Job support using new `run_at` Job field.
 - Reschedule endpoint allowing the Job Runner to manage a unique/singleton Job rescheduling itself.
 
-[Unreleased]: https://github.com/rust-playground/relay-rs/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/rust-playground/relay-rs/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/rust-playground/relay-rs/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/rust-playground/relay-rs/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/rust-playground/relay-rs/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/rust-playground/relay-rs/compare/v0.5.0...v0.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-compression"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
+checksum = "8589c784ff02ac80dafc5e4116c3a2a3743ac5e0c902483518a88eec6559cf99"
 dependencies = [
  "flate2",
  "futures-core",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.17"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47582c09be7c8b32c0ab3a6181825ababb713fde6fff20fc573a3870dd45c6a0"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1208,25 +1208,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1259,15 +1248,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1585,7 +1565,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "relay"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "actix-web",
  "anydate",
@@ -2135,9 +2115,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2265,9 +2245,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.1"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
  "bytes",
  "libc",

--- a/relay/API.md
+++ b/relay/API.md
@@ -173,13 +173,14 @@ the option of being self-perpetuated in combination with the `run_at` field.
 #### Arguments
 In this case the only arguments are part of the Body payload.
 
-| argument    | required | description                                                                                                                                                                            |
-|-------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| argument      | required | description                                                                                                                                                                            |
+|---------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `id`          | true     | The unique Job Id which is also CAN be used to ensure the Job is a singleton within a Queue.                                                                                           |
 | `queue`       | true     | Is used to differentiate different job types that can be picked up by job runners.                                                                                                     |
 | `timeout`     | true     | Denotes the duration, in seconds, after a Job has started processing or since the last heartbeat request occurred before considering the Job failed and being put back into the queue. |
 | `max_retries` | false    | Determines how many times the Job can be retried, due to timeouts, before being considered.                                                                                            |
 | `payload`     | false    | The raw JSON payload that the job runner will receive.                                                                                                                                 |
+| `state`       | false    | The raw JSON state for the rescheduled Job. If NOT supplied will be reset to nil like a newly enqueued Job.                                                                            |
 | `run_at`      | false    | Schedule/set a Job to be run only at a specific time in the future.                                                                                                                    |
 
 #### Request Body

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "relay"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.57"
-clap = { version = "3.1.17", features = ["derive", "env"] }
-tokio = { version = "1.18.1", features = ["rt-multi-thread", "net", "time","macros"] }
+clap = { version = "3.1.18", features = ["derive", "env"] }
+tokio = { version = "1.18.2", features = ["rt-multi-thread", "net", "time","macros"] }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 metrics-exporter-prometheus = { version = "0.9.0", optional = true }
 metrics-util = "0.12.1"

--- a/relay/src/http.rs
+++ b/relay/src/http.rs
@@ -173,13 +173,14 @@
 //! #### Arguments
 //! In this case the only arguments are part of the Body payload.
 //!
-//! | argument    | required | description                                                                                                                                                                            |
-//! |-------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+//! | argument    | required | description                                                                                                                                                                              |
+//! |-------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 //! | `id`          | true     | The unique Job Id which is also CAN be used to ensure the Job is a singleton within a Queue.                                                                                           |
 //! | `queue`       | true     | Is used to differentiate different job types that can be picked up by job runners.                                                                                                     |
 //! | `timeout`     | true     | Denotes the duration, in seconds, after a Job has started processing or since the last heartbeat request occurred before considering the Job failed and being put back into the queue. |
 //! | `max_retries` | false    | Determines how many times the Job can be retried, due to timeouts, before being considered.                                                                                            |
 //! | `payload`     | false    | The raw JSON payload that the job runner will receive.                                                                                                                                 |
+//! | `state`       | false    | The raw JSON state for the rescheduled Job. If NOT supplied will be reset to nil like a newly enqueued Job.                                                                            |
 //! | `run_at`      | false    | Schedule/set a Job to be run only at a specific time in the future.                                                                                                                    |
 //!
 //! #### Request Body

--- a/relay/src/jobs.rs
+++ b/relay/src/jobs.rs
@@ -28,9 +28,8 @@ pub struct RawJob {
 
     /// The raw JSON payload that the job runner will receive.
     ///
-    /// This state will be ignored when enqueueing a Job and can only be set via a Heartbeat
-    /// request.
-    #[serde(skip_deserializing)]
+    /// This state will be ignored when enqueueing a Job and can only be set via a Heartbeat or
+    /// Reschedule request.
     pub state: Option<Box<RawValue>>,
 
     /// With this you can optionally schedule/set a Job to be run only at a specific time in the

--- a/relay/src/postgres.rs
+++ b/relay/src/postgres.rs
@@ -351,9 +351,10 @@ impl PgStore {
                     max_retries = $4,
                     retries_remaining = $4,
                     data = $5,
-                    updated_at = $6,
-                    created_at = $6,
-                    run_at = $7,
+                    state = $6,
+                    updated_at = $7,
+                    created_at = $7,
+                    run_at = $8,
                     in_flight = false
                 WHERE
                     queue=$1 AND
@@ -370,6 +371,7 @@ impl PgStore {
         })
         .bind(job.max_retries)
         .bind(Json(&job.payload))
+        .bind(job.state.as_ref().map(|state| Some(Json(state))))
         .bind(&now)
         .bind(&run_at)
         .execute(&self.pool)


### PR DESCRIPTION
This changes reschedule to allow `setting/unsetting` of `state` which was
previously not supported.

This change does **NOT** change `state` being ignored by enqueue. This is a concious decision to avoid tight-coupling and abstraction leakage. 

The Worker/Consumer of Jobs sets and owns the state which the Enqueuers need
know nothing about.